### PR TITLE
Start Embedded PostgreSQL in separate thread with its own ClassLoader

### DIFF
--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/classloader/ClassLoaderHolder.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/classloader/ClassLoaderHolder.java
@@ -1,0 +1,18 @@
+package com.github.slavaz.maven.plugin.postgresql.embedded.classloader;
+
+import java.util.Optional;
+
+public class ClassLoaderHolder {
+    private static Optional<ClassLoader> instance = Optional.empty();
+
+    public static void setClassLoader(ClassLoader classLoader) {
+        if (instance.isPresent()) {
+            throw new IllegalStateException("ClassLoader instance already set");
+        }
+        instance = Optional.of(classLoader);
+    }
+
+    public static Optional<ClassLoader> getClassLoader() {
+        return instance;
+    }
+}

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/classloader/ClassLoaderUtils.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/classloader/ClassLoaderUtils.java
@@ -1,0 +1,28 @@
+package com.github.slavaz.maven.plugin.postgresql.embedded.classloader;
+
+import org.apache.maven.artifact.Artifact;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+
+public class ClassLoaderUtils {
+    public static ClassLoader buildClassLoader(List<Artifact> artifacts) {
+        return new URLClassLoader(artifacts.stream()
+                .map(Artifact::getFile)
+                .map(File::toURI)
+                .map(ClassLoaderUtils::uriToURL)
+                .toArray(URL[]::new));
+    }
+
+    private static URL uriToURL(URI uri) {
+        try {
+            return uri.toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Malformed URL: " + uri, e);
+        }
+    }
+}

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/goals/StopGoalMojo.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/goals/StopGoalMojo.java
@@ -1,9 +1,12 @@
 package com.github.slavaz.maven.plugin.postgresql.embedded.goals;
 
-import com.github.slavaz.maven.plugin.postgresql.embedded.psql.PgInstanceManager;
+import com.github.slavaz.maven.plugin.postgresql.embedded.classloader.ClassLoaderHolder;
+import com.github.slavaz.maven.plugin.postgresql.embedded.psql.IsolatedPgInstanceManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+
+import java.util.Optional;
 
 /**
  * Created by slavaz on 13/02/17.
@@ -11,14 +14,17 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "stop")
 public class StopGoalMojo extends AbstractGoalMojo {
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
-        try {
-            getLog().info("Stopping PostgreSQL...");
-            new PgInstanceManager().stop();
-            getLog().debug("PostgreSQL stopped.");
-        } catch (Exception e) {
-            getLog().error("Failed to stop PostgreSQL", e);
+        Optional<ClassLoader> classLoader = ClassLoaderHolder.getClassLoader();
+        if (classLoader.isPresent()) {
+            try {
+                getLog().info("Stopping PostgreSQL...");
+                new IsolatedPgInstanceManager(classLoader.get()).stop();
+                getLog().debug("PostgreSQL stopped.");
+            } catch (Exception e) {
+                getLog().error("Failed to stop PostgreSQL", e);
+            }
+        } else {
+            getLog().warn("PostgreSQL was not started");
         }
     }
-    
-    
 }

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IPgInstanceProcessData.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IPgInstanceProcessData.java
@@ -1,13 +1,6 @@
 package com.github.slavaz.maven.plugin.postgresql.embedded.psql;
 
-import ru.yandex.qatools.embed.postgresql.PostgresProcess;
-
 public interface IPgInstanceProcessData {
-
-    PostgresProcess getProcess();
-
-    void setProcess(PostgresProcess process);
-
     String getPgServerVersion();
 
     void setPgServerVersion(String pgServerVersion);

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IsolatedPgInstanceManager.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IsolatedPgInstanceManager.java
@@ -1,0 +1,82 @@
+package com.github.slavaz.maven.plugin.postgresql.embedded.psql;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Starts a PostgreSQL instance in a separate thread using a separate classloader. This is necessary, because the
+ * Embedded PostgreSQL registers a shutdown hook which is run when the JVM shuts down, to shut down the process. When a
+ * build fails, this plugin's "stop" goal is never run, so we rely on the shutdown hook to shut down PostgreSQL and
+ * clean up resources. However, Maven plugins run in separate class loaders, which means the required classes to shut
+ * down PostgreSQL are not available any more in the shutdown hook. By starting a thread with our own class loader,
+ * we ensure that the classes are available during the shutdown hook.
+ */
+public class IsolatedPgInstanceManager {
+    private final ClassLoader classLoader;
+
+    public IsolatedPgInstanceManager(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    public void start(IPgInstanceProcessData data) throws IOException {
+        Thread postgresThread = new Thread(() -> {
+            Method startPostgres = getMethod("startPostgres", String.class, int.class, String.class, String.class, String.class, String.class, String.class, String.class);
+
+            invokeStaticMethod(startPostgres, data.getPgServerVersion(), data.getPgPort(), data.getDbName(), data.getUserName(),
+                    data.getPassword(), data.getPgDatabaseDir(), data.getPgLocale(), data.getPgCharset());
+
+        }, "postgres-embedded");
+        postgresThread.setContextClassLoader(classLoader);
+        postgresThread.start();
+
+        try {
+            postgresThread.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Embedded Postgres thread was interrupted", e);
+        }
+    }
+
+    public void stop() {
+        invokeStaticMethod(getMethod("stopPostgres"));
+    }
+
+    @SuppressWarnings("unused")
+    public static void startPostgres(String pgServerVersion, int pgPort, String dbName, String userName, String password,
+                                     String pgDatabaseDir, String pgLocale, String pgCharset) throws IOException {
+        PgInstanceManager.start(new PgInstanceProcessData(pgServerVersion, pgPort, dbName, userName, password, pgDatabaseDir, pgLocale, pgCharset));
+    }
+
+    @SuppressWarnings("unused")
+    public static void stopPostgres() throws InterruptedException {
+        PgInstanceManager.stop();
+    }
+
+    private Method getMethod(String methodName, Class<?>... parameterTypes) {
+        Class<?> managerClass = loadClass(IsolatedPgInstanceManager.class.getName());
+        try {
+            return managerClass.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("No method " + methodName + " on " + managerClass, e);
+        }
+    }
+
+    private Class loadClass(String className) {
+        try {
+            return classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Class not found: " + className, e);
+        }
+    }
+
+    private static void invokeStaticMethod(Method m, Object... arguments) {
+        try {
+            m.invoke(null, arguments);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Method " + m.getName() + " not accessible", e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException("Invocation of method " + m.getName() + " threw exception", e);
+        }
+    }
+
+}

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgInstanceProcessData.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgInstanceProcessData.java
@@ -1,16 +1,9 @@
 package com.github.slavaz.maven.plugin.postgresql.embedded.psql;
 
-import ru.yandex.qatools.embed.postgresql.PostgresProcess;
-
 /**
  * Created by slavaz on 13/02/17.
  */
 public class PgInstanceProcessData implements IPgInstanceProcessData {
-
-    private static PgInstanceProcessData instance;
-
-    private PostgresProcess process;
-
     private String pgServerVersion;
 
     private int pgPort;
@@ -27,26 +20,18 @@ public class PgInstanceProcessData implements IPgInstanceProcessData {
 
     private String pgCharset;
 
-    private PgInstanceProcessData() {
+    public PgInstanceProcessData(String pgServerVersion, int pgPort, String dbName, String userName, String password, String pgDatabaseDir, String pgLocale, String pgCharset) {
+        this.pgServerVersion = pgServerVersion;
+        this.pgPort = pgPort;
+        this.dbName = dbName;
+        this.userName = userName;
+        this.password = password;
+        this.pgDatabaseDir = pgDatabaseDir;
+        this.pgLocale = pgLocale;
+        this.pgCharset = pgCharset;
     }
 
-    public static PgInstanceProcessData getInstance() {
-        if (instance == null) {
-            synchronized (PgInstanceProcessData.class) {
-                if (instance == null) {
-                    instance = new PgInstanceProcessData();
-                }
-            }
-        }
-        return instance;
-    }
-
-    public PostgresProcess getProcess() {
-        return process;
-    }
-
-    public void setProcess(PostgresProcess process) {
-        this.process = process;
+    public PgInstanceProcessData() {
     }
 
     public String getPgServerVersion() {

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
@@ -14,9 +14,9 @@ public enum PgVersion {
     V9_5(new String[] { "9.5", "9.5.5" }, Version.V9_5_5),
     V9_6(new String[] { "9.6", "9.6.1" }, Version.V9_6_1),
 
-    DEFAUILT(V9_6),
+    DEFAULT(V9_6),
 
-    LATEST(new String[] { "default", "latest" }, DEFAUILT);
+    LATEST(new String[] { "default", "latest" }, DEFAULT);
 
     final private String[] aliases;
     final private IVersion version;
@@ -44,7 +44,7 @@ public enum PgVersion {
                         .isPresent()
                 )
                 .findFirst()
-                .orElse(DEFAUILT)
+                .orElse(DEFAULT)
                 .version;
     }
 }


### PR DESCRIPTION
This starts the PostgreSQL instance in a separate thread using its own ClassLoader. I had to do some editing of some of the code to make it work, to ensure that the interaction between class loaders is smooth (eg. can't use a singleton `IPgInstanceProcessData` any more, as the instance is not transferred between class loaders).

The main way it works is:
- Create a class loader based on the plugin dependencies (from `${plugin.artifacts}`)
- Create a thread and set its `ContextClassLoader` to that class loader
- Start the PostgreSQL process inside of it
- When stopping, grab an instance of the same class loader, call the appropriate `stop` method on the correct class inside the class loader

This ensures that during the shutdown hook, all the required classes are available.

The funky business with `ClassLoader.loadClass(..).getMethod(..)` is there because in the body of the Thread's `Runnable`, you are basically still dealing with the classes of the parent class loader, so any instance you create or (static) method call you do, will be in the parent class loader, actually (you can compare this by logging the difference between `IsolatedPgInstanceManager.class.getClassLoader()`, `classLoader`, and `classLoader.loadClass(IsolatedPgInstanceManager.class.getName()).getClassLoader()`).

The effect is that even when `stop()` isn't called (either because the build fails eg. due to a compilation failure or someone just forgets to configure the goal), the `postgres` process is still terminated.

You can easily test this. Just create an empty maven project with the plugin, and put some class in it with a syntax error. You will see that with the current `master` version, the plugin will keep running after the compilation failure, but with my changes the process will quit.