### PR TITLE
Updated postgresql-embedded to version 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>ru.yandex.qatools.embed</groupId>
             <artifactId>postgresql-embedded</artifactId>
-            <version>1.20</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
@@ -9,10 +9,9 @@ import java.util.stream.Stream;
  * Created by slavaz on 13/02/17.
  */
 public enum PgVersion {
-    V9_3(new String[] { "9.3", "9.3.15" }, Version.V9_3_15),
     V9_4(new String[] { "9.4", "9.4.10" }, Version.V9_4_10),
     V9_5(new String[] { "9.5", "9.5.5" }, Version.V9_5_5),
-    V9_6(new String[] { "9.6", "9.6.1" }, Version.V9_6_1),
+    V9_6(new String[] { "9.6", "9.6.2" }, Version.V9_6_2),
 
     DEFAULT(V9_6),
 

--- a/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
+++ b/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
@@ -17,18 +17,16 @@ public class PgVersionTest {
     protected Object[][] getVersionsDataSource() {
         // @formatter:off
         return new Object[][] {
-                { null, Version.V9_6_1 },
-                {"latest", Version.V9_6_1 },
-                {"default", Version.V9_6_1 },
-                {"9.3", Version.V9_3_15},
-                {"9.3.15", Version.V9_3_15},
+                { null, Version.V9_6_2 },
+                {"latest", Version.V9_6_2 },
+                {"default", Version.V9_6_2 },
                 {"9.4", Version.V9_4_10},
                 {"9.4.10", Version.V9_4_10},
                 {"9.5", Version.V9_5_5},
                 {"9.5.5", Version.V9_5_5},
-                {"9.6", Version.V9_6_1},
-                {"9.6.1", Version.V9_6_1},
-                {"bla-bla-bla", Version.V9_6_1 },
+                {"9.6", Version.V9_6_2},
+                {"9.6.2", Version.V9_6_2},
+                {"bla-bla-bla", Version.V9_6_2 },
 
         };
         // @formatter:on


### PR DESCRIPTION
The latest version of `postgresql-embedded` as of writing is 2.2. The main improvement for me is that files are not extracted individually any more, but in one go, making the process much faster (and with much less log output).

However, they don't support PostgreSQL version 9.3 any more through the enum (and the 9.6 version has changed to 9.6.2). So if you or anyone you know uses 9.3 with thus plugin, this might be an issue (unless it's changed to allow any custom version, which `postgresql-embedded` does support by implementing `IVersion`).

Unfortunately I was unable to find a full changelog between 1.20 and 2.2.