### PR TITLE
Update postgresql-embedded to 2.5 and support postgres 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ This plugin  is based on [Embedded PostgreSQL Server library](https://github.com
 
 ### pgServerVersion
 
-The plugin currently supports next PostgreSQL versions: 9.4.10, 9.5.5, 9.6.1
+The plugin currently supports next PostgreSQL versions: 9.5.7, 9.6.5, 10.0
 
 You also may use aliases:
-* 9.4 -> 9.4.10
-* 9.5 -> 9.5.5
-* 9.6 -> 9.6.2
-* latest -> 9.6
+* 9.5 -> 9.5.7
+* 9.6 -> 9.6.5
+* latest -> 10.0
 
 ### pgDatabaseDir
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>ru.yandex.qatools.embed</groupId>
             <artifactId>postgresql-embedded</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
  * Created by slavaz on 13/02/17.
  */
 public enum PgVersion {
+    V9_4(new String[]{"9.4", "9.4.14"}, VersionEx.V9_4_14),
     V9_5(new String[] { "9.5", "9.5.7" }, Version.V9_5_7),
     V9_6(new String[] { "9.6", "9.6.5" }, Version.V9_6_5),
     V10_0(new String[] { "10.0" }, Version.V10_0),

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
@@ -9,11 +9,11 @@ import java.util.stream.Stream;
  * Created by slavaz on 13/02/17.
  */
 public enum PgVersion {
-    V9_4(new String[] { "9.4", "9.4.10" }, Version.V9_4_10),
-    V9_5(new String[] { "9.5", "9.5.5" }, Version.V9_5_5),
-    V9_6(new String[] { "9.6", "9.6.2" }, Version.V9_6_2),
+    V9_5(new String[] { "9.5", "9.5.7" }, Version.V9_5_7),
+    V9_6(new String[] { "9.6", "9.6.5" }, Version.V9_6_5),
+    V10_0(new String[] { "10.0" }, Version.V10_0),
 
-    DEFAULT(V9_6),
+    DEFAULT(V10_0),
 
     LATEST(new String[] { "default", "latest" }, DEFAULT);
 

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/VersionEx.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/VersionEx.java
@@ -1,0 +1,28 @@
+package com.github.slavaz.maven.plugin.postgresql.embedded.psql;
+
+import de.flapdoodle.embed.process.distribution.IVersion;
+
+/**
+ * Add support for more Postgresql Versions which are not supported by {@code postgres-embedded}.
+ *
+ * @see ru.yandex.qatools.embed.postgresql.distribution.Version
+ * @see IVersion
+ */
+public enum VersionEx implements IVersion {
+    V9_4_14("9.4.14-1");
+
+    private final String specificVersion;
+
+    VersionEx(String vName) {
+        this.specificVersion = vName;
+    }
+
+    public String asInDownloadPath() {
+        return this.specificVersion;
+    }
+
+    public String toString() {
+        return "Version{" + this.specificVersion + '}';
+    }
+}
+

--- a/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
+++ b/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
@@ -17,16 +17,14 @@ public class PgVersionTest {
     protected Object[][] getVersionsDataSource() {
         // @formatter:off
         return new Object[][] {
-                { null, Version.V9_6_2 },
-                {"latest", Version.V9_6_2 },
-                {"default", Version.V9_6_2 },
-                {"9.4", Version.V9_4_10},
-                {"9.4.10", Version.V9_4_10},
-                {"9.5", Version.V9_5_5},
-                {"9.5.5", Version.V9_5_5},
-                {"9.6", Version.V9_6_2},
-                {"9.6.2", Version.V9_6_2},
-                {"bla-bla-bla", Version.V9_6_2 },
+                { null, Version.V10_0 },
+                {"latest", Version.V10_0 },
+                {"default", Version.V10_0 },
+                {"9.5", Version.V9_5_7},
+                {"9.5.7", Version.V9_5_7},
+                {"9.6", Version.V9_6_5},
+                {"9.6.5", Version.V9_6_5},
+                {"bla-bla-bla", Version.V10_0 },
 
         };
         // @formatter:on

--- a/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
+++ b/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
@@ -20,6 +20,7 @@ public class PgVersionTest {
                 { null, Version.V10_0 },
                 {"latest", Version.V10_0 },
                 {"default", Version.V10_0 },
+                {"9.4", VersionEx.V9_4_14},
                 {"9.5", Version.V9_5_7},
                 {"9.5.7", Version.V9_5_7},
                 {"9.6", Version.V9_6_5},


### PR DESCRIPTION
`postgres-embedded` version 2.5 has been released, with support for Postgresql 10 which was released earlier this month. See [this issue](https://github.com/yandex-qatools/postgresql-embedded/pull/102).

Some more information about Postgresql 10:
- https://wiki.postgresql.org/wiki/New_in_postgres_10
- https://www.postgresql.org/about/news/1786/
- https://www.postgresql.org/docs/10/static/release-10.html