### PR TITLE
Added ability to configure host(property pgHost)

### DIFF
--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/goals/StartGoalMojo.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/goals/StartGoalMojo.java
@@ -46,6 +46,9 @@ public class StartGoalMojo extends AbstractGoalMojo {
     @Parameter(property = "pgCharset")
     private String pgCharset;
 
+    @Parameter(property = "pgHost")
+    private String pgHost;
+
     @Parameter(defaultValue = "5432", property = "pgPort", required = true)
     private int pgServerPort;
 
@@ -75,7 +78,7 @@ public class StartGoalMojo extends AbstractGoalMojo {
     }
 
     private IPgInstanceProcessData buildInstanceProcessData() {
-        return new PgInstanceProcessData(pgServerVersion, pgServerPort,
+        return new PgInstanceProcessData(pgServerVersion, pgHost, pgServerPort,
                 dbName, userName, password, pgDatabaseDir, pgLocale, pgCharset);
     }
 }

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IPgInstanceProcessData.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IPgInstanceProcessData.java
@@ -5,6 +5,10 @@ public interface IPgInstanceProcessData {
 
     void setPgServerVersion(String pgServerVersion);
 
+    String getPgHost();
+
+    void setPgHost(String pgHost);
+
     String getDbName();
 
     void setDbName(String dbName);

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IsolatedPgInstanceManager.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/IsolatedPgInstanceManager.java
@@ -23,9 +23,9 @@ public class IsolatedPgInstanceManager {
 
     public void start(IPgInstanceProcessData data) throws IOException {
         Thread postgresThread = new Thread(() -> {
-            Method startPostgres = getMethod("startPostgres", String.class, int.class, String.class, String.class, String.class, String.class, String.class, String.class);
+            Method startPostgres = getMethod("startPostgres", String.class, String.class, int.class, String.class, String.class, String.class, String.class, String.class, String.class);
 
-            invokeStaticMethod(startPostgres, data.getPgServerVersion(), data.getPgPort(), data.getDbName(), data.getUserName(),
+            invokeStaticMethod(startPostgres, data.getPgServerVersion(), data.getPgHost(), data.getPgPort(), data.getDbName(), data.getUserName(),
                     data.getPassword(), data.getPgDatabaseDir(), data.getPgLocale(), data.getPgCharset());
 
         }, "postgres-embedded");
@@ -44,9 +44,9 @@ public class IsolatedPgInstanceManager {
     }
 
     @SuppressWarnings("unused")
-    public static void startPostgres(String pgServerVersion, int pgPort, String dbName, String userName, String password,
+    public static void startPostgres(String pgServerVersion, String pgHost, int pgPort, String dbName, String userName, String password,
                                      String pgDatabaseDir, String pgLocale, String pgCharset) throws IOException {
-        PgInstanceManager.start(new PgInstanceProcessData(pgServerVersion, pgPort, dbName, userName, password, pgDatabaseDir, pgLocale, pgCharset));
+        PgInstanceManager.start(new PgInstanceProcessData(pgServerVersion, pgHost, pgPort, dbName, userName, password, pgDatabaseDir, pgLocale, pgCharset));
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgInstanceManager.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgInstanceManager.java
@@ -68,7 +68,8 @@ public class PgInstanceManager {
     }
 
     private static AbstractPostgresConfig.Net getNet(IPgInstanceProcessData pgInstanceProcessData) throws IOException {
-        return new AbstractPostgresConfig.Net(getLocalHost().getHostAddress(), pgInstanceProcessData.getPgPort());
+        String host = "".equals(pgInstanceProcessData.getPgHost()) ? getLocalHost().getHostAddress() : pgInstanceProcessData.getPgHost();
+        return new AbstractPostgresConfig.Net(host, pgInstanceProcessData.getPgPort());
     }
 
     private static IVersion getVersion(IPgInstanceProcessData pgInstanceProcessData) {

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/data/PgInstanceProcessData.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/data/PgInstanceProcessData.java
@@ -8,6 +8,8 @@ import com.github.slavaz.maven.plugin.postgresql.embedded.psql.IPgInstanceProces
 public class PgInstanceProcessData implements IPgInstanceProcessData {
     private String pgServerVersion;
 
+    private String pgHost;
+
     private int pgPort;
 
     private String dbName;
@@ -22,8 +24,9 @@ public class PgInstanceProcessData implements IPgInstanceProcessData {
 
     private String pgCharset;
 
-    public PgInstanceProcessData(String pgServerVersion, int pgPort, String dbName, String userName, String password, String pgDatabaseDir, String pgLocale, String pgCharset) {
+    public PgInstanceProcessData(String pgServerVersion, String pgHost, int pgPort, String dbName, String userName, String password, String pgDatabaseDir, String pgLocale, String pgCharset) {
         this.pgServerVersion = pgServerVersion;
+        this.pgHost = pgHost;
         this.pgPort = pgPort;
         this.dbName = dbName;
         this.userName = userName;
@@ -42,6 +45,14 @@ public class PgInstanceProcessData implements IPgInstanceProcessData {
 
     public void setPgServerVersion(String pgServerVersion) {
         this.pgServerVersion = pgServerVersion;
+    }
+
+    public String getPgHost() {
+        return pgHost;
+    }
+
+    public void setPgHost(String pgHost) {
+        this.pgHost = pgHost;
     }
 
     public String getDbName() {


### PR DESCRIPTION
There is a problem with default host while using this plugin in conjunction with other(e.g.flyway-maven-plugin, querydsl-maven-plugin). 
If "hosts" file contains for example: 
127.0.0.1	localhost
127.0.1.1	user-pc
then postgres starts on 127.0.1.1 instead of 127.0.0.1.