### PR TITLE
Upgrade postgresql-embedded and flapdoodle.embed.process dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,17 @@
         <dependency>
             <groupId>ru.yandex.qatools.embed</groupId>
             <artifactId>postgresql-embedded</artifactId>
-            <version>2.5</version>
+            <version>2.10</version>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.process</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
+++ b/src/main/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersion.java
@@ -9,12 +9,12 @@ import java.util.stream.Stream;
  * Created by slavaz on 13/02/17.
  */
 public enum PgVersion {
-    V9_4(new String[]{"9.4", "9.4.14"}, VersionEx.V9_4_14),
-    V9_5(new String[] { "9.5", "9.5.7" }, Version.V9_5_7),
-    V9_6(new String[] { "9.6", "9.6.5" }, Version.V9_6_5),
-    V10_0(new String[] { "10.0" }, Version.V10_0),
+    V9_4(new String[] { "9.4", "9.4.14"}, VersionEx.V9_4_14),
+    V9_5(new String[] { "9.5", "9.5.15" }, Version.V9_5_15),
+    V9_6(new String[] { "9.6", "9.6.11" }, Version.V9_6_11),
+    V10(new String[] { "10", "10.6" }, Version.V10_6),
 
-    DEFAULT(V10_0),
+    DEFAULT(V10),
 
     LATEST(new String[] { "default", "latest" }, DEFAULT);
 

--- a/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
+++ b/src/test/java/com/github/slavaz/maven/plugin/postgresql/embedded/psql/PgVersionTest.java
@@ -17,15 +17,17 @@ public class PgVersionTest {
     protected Object[][] getVersionsDataSource() {
         // @formatter:off
         return new Object[][] {
-                { null, Version.V10_0 },
-                {"latest", Version.V10_0 },
-                {"default", Version.V10_0 },
+                { null, Version.V10_6 },
+                {"latest", Version.V10_6 },
+                {"default", Version.V10_6 },
                 {"9.4", VersionEx.V9_4_14},
-                {"9.5", Version.V9_5_7},
-                {"9.5.7", Version.V9_5_7},
-                {"9.6", Version.V9_6_5},
-                {"9.6.5", Version.V9_6_5},
-                {"bla-bla-bla", Version.V10_0 },
+                {"9.5", Version.V9_5_15},
+                {"9.5.15", Version.V9_5_15},
+                {"9.6", Version.V9_6_11},
+                {"9.6.11", Version.V9_6_11},
+                {"10", Version.V10_6},
+                {"10.6", Version.V10_6},
+                {"bla-bla-bla", Version.V10_6 },
 
         };
         // @formatter:on


### PR DESCRIPTION
- Upgrade to postgresql-embedded 2.10 ; flapdoodle.embed.process 2.1.2
- Add commons-io as a dependency for tests as flapdoodle.embed.process does not use it anymore
- Upgrade supported PostgreSQL version's according to postgresql-embedded